### PR TITLE
Update pymoo==0.6.0 to support newer numpy version

### DIFF
--- a/HEBO/requirements.txt
+++ b/HEBO/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16
 pandas>=1.0.1
 torch>=1.9.0
-pymoo==0.5.0
+pymoo==0.6.0
 scikit-learn>=0.22
 gpytorch>=1.4.0
 GPy>=1.9.9


### PR DESCRIPTION
numpy removed np.object which `pymoo==0.5.0` uses. To support newer numpy version we need to update pymoo