### PR TITLE
Fix build failures due to missing dependencies in package.xml

### DIFF
--- a/ROSLLM/rosllm_msgs/package.xml
+++ b/ROSLLM/rosllm_msgs/package.xml
@@ -53,6 +53,9 @@
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <build_depend>sensor_msgs</build_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/ROSLLM/rosllm_srvs/package.xml
+++ b/ROSLLM/rosllm_srvs/package.xml
@@ -20,4 +20,9 @@
   <build_export_depend>sensor_msgs</build_export_depend>
   <exec_depend>sensor_msgs</exec_depend>
 
+  <build_depend>rosllm_msgs</build_depend>
+  <build_export_depend>rosllm_msgs</build_export_depend>
+  <exec_depend>rosllm_msgs</exec_depend>
+
+
 </package>


### PR DESCRIPTION
I have updated the `package.xml` files in two ROSLLM packages. The dependencies listed in `CMakeLists.txt` were not synchronized with `package.xml`, which leads to build failures.

Specifically:
- The `rosllm_srvs` package depends on `rosllm_msgs`, but this was missing from `package.xml`. This caused build errors due to undefined compilation order.
- The `rosllm_msgs` package depends on `sensor_msgs`, which was also missing from its `package.xml`.

I have fixed both issues, and the project now builds successfully on my machine.
