### PR TITLE
fix: keep bool parameters as bool in sklearn_tuner (#108)

### DIFF
--- a/HEBO/hebo/sklearn_tuner.py
+++ b/HEBO/hebo/sklearn_tuner.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import warnings
 from hebo.design_space.design_space import DesignSpace
+from hebo.design_space.bool_param   import BoolPara
 from hebo.optimizers.hebo import HEBO
 from sklearn.model_selection import cross_val_predict, KFold
 from typing import Callable
@@ -75,7 +76,10 @@ def sklearn_tuner(
         rec = opt.suggest()
         hyp = rec.iloc[0].to_dict()
         for k in hyp:
-            if space.paras[k].is_numeric and space.paras[k].is_discrete:
+            para = space.paras[k]
+            if isinstance(para, BoolPara):
+                hyp[k] = bool(hyp[k])
+            elif para.is_numeric and para.is_discrete:
                 hyp[k] = int(hyp[k])
         model = model_class(**hyp)
         pred = cross_val_predict(model, X, y, cv=cv)

--- a/HEBO/test/test_sklearn_tuner_bool.py
+++ b/HEBO/test/test_sklearn_tuner_bool.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2020. Huawei Technologies Co., Ltd. All rights reserved.
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the MIT license.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the MIT License for more details.
+
+import sys, os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)) + '/../')
+
+import pytest
+import numpy as np
+from sklearn.base    import BaseEstimator, RegressorMixin
+from sklearn.metrics import r2_score
+
+from hebo.sklearn_tuner import sklearn_tuner
+
+
+class _TypeRecorder(BaseEstimator, RegressorMixin):
+    """Records the python type of each hyper-parameter it receives at fit time."""
+    seen = []
+
+    def __init__(self, flag = True, depth = 1):
+        self.flag  = flag
+        self.depth = depth
+
+    def fit(self, X, y):
+        _TypeRecorder.seen.append((type(self.flag).__name__, type(self.depth).__name__))
+        self.mean_ = float(np.mean(y))
+        return self
+
+    def predict(self, X):
+        return np.full(len(X), self.mean_)
+
+
+def test_bool_param_stays_bool():
+    # Regression test for issue #108: a `bool` parameter must reach the
+    # estimator as a python bool, not be coerced to int (0/1).
+    _TypeRecorder.seen = []
+    space_cfg = [
+        {'name' : 'flag',  'type' : 'bool'},
+        {'name' : 'depth', 'type' : 'int', 'lb' : 1, 'ub' : 5},
+    ]
+    X, y = np.random.randn(40, 2), np.random.randn(40)
+    sklearn_tuner(_TypeRecorder, space_cfg, X, y,
+                  metric = r2_score, max_iter = 3, verbose = False)
+
+    flag_types  = {t[0] for t in _TypeRecorder.seen}
+    depth_types = {t[1] for t in _TypeRecorder.seen}
+    assert _TypeRecorder.seen, "estimator was never fitted"
+    assert flag_types  == {'bool'}, f"bool param coerced to {flag_types}, expected bool"
+    assert depth_types == {'int'},  f"int param became {depth_types}, expected int"


### PR DESCRIPTION
## Summary

`sklearn_tuner` int-casts every discrete numeric hyper-parameter:

```python
if space.paras[k].is_numeric and space.paras[k].is_discrete:
    hyp[k] = int(hyp[k])
```

`BoolPara` reports **both** `is_numeric` and `is_discrete` as `True`, so a boolean hyper-parameter (e.g. a `RandomForest`'s `bootstrap`) is cast to `0`/`1`. Modern scikit-learn then rejects it:

> The 'bootstrap' parameter ... must be an instance of 'bool' ... Got 0 instead.

This is issue #108.

## Fix

Special-case `BoolPara` so boolean parameters stay python `bool`, and only int-cast the remaining (non-bool) discrete numerics.

## Tests

Adds `test/test_sklearn_tuner_bool.py` — a recorder estimator that asserts the parameter *type* it receives at `fit`. Fails before the fix (`bool` coerced to `int`), passes after.

```
1 passed
```

Closes #108.
