### PR TITLE
fix: don't globally silence warnings on importing sklearn_tuner

### DIFF
--- a/HEBO/hebo/sklearn_tuner.py
+++ b/HEBO/hebo/sklearn_tuner.py
@@ -15,8 +15,6 @@ from hebo.optimizers.hebo import HEBO
 from sklearn.model_selection import cross_val_predict, KFold
 from typing import Callable
 
-warnings.filterwarnings('ignore')
-
 
 def sklearn_tuner(
         model_class,
@@ -72,18 +70,20 @@ def sklearn_tuner(
     if cv is None:
         cv = KFold(n_splits=5, shuffle=True, random_state=42)
     for i in range(max_iter):
-        rec = opt.suggest()
-        hyp = rec.iloc[0].to_dict()
-        for k in hyp:
-            if space.paras[k].is_numeric and space.paras[k].is_discrete:
-                hyp[k] = int(hyp[k])
-        model = model_class(**hyp)
-        pred = cross_val_predict(model, X, y, cv=cv)
-        score_v = metric(y, pred)
-        sign = -1. if greater_is_better else 1.0
-        opt.observe(rec, np.array([sign * score_v]))
-        if verbose:
-            print('Iter %d, best metric: %g' % (i, sign * opt.y.min()), flush=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            rec = opt.suggest()
+            hyp = rec.iloc[0].to_dict()
+            for k in hyp:
+                if space.paras[k].is_numeric and space.paras[k].is_discrete:
+                    hyp[k] = int(hyp[k])
+            model = model_class(**hyp)
+            pred = cross_val_predict(model, X, y, cv=cv)
+            score_v = metric(y, pred)
+            sign = -1. if greater_is_better else 1.0
+            opt.observe(rec, np.array([sign * score_v]))
+            if verbose:
+                print('Iter %d, best metric: %g' % (i, sign * opt.y.min()), flush=True)
     best_id = np.argmin(opt.y.reshape(-1))
     best_hyp = opt.X.iloc[best_id]
     df_report = opt.X.copy()

--- a/HEBO/test/test_sklearn_tuner_warnings.py
+++ b/HEBO/test/test_sklearn_tuner_warnings.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2020. Huawei Technologies Co., Ltd. All rights reserved.
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the MIT license.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the MIT License for more details.
+
+import sys, os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)) + '/../')
+
+import importlib
+import warnings
+
+import pytest
+
+
+def _head_filter_action():
+    """Return the action of the highest-priority entry in warnings.filters."""
+    return warnings.filters[0][0] if warnings.filters else None
+
+
+def test_import_does_not_install_global_ignore_filter():
+    # Regression test: importing hebo.sklearn_tuner must NOT install a
+    # process-wide 'ignore' warning filter. A library silencing every
+    # warning of the host program just by being imported is a side effect
+    # that hides the user's own warnings.
+    with warnings.catch_warnings():
+        warnings.resetwarnings()
+        warnings.simplefilter('default')
+
+        import hebo.sklearn_tuner as st
+        importlib.reload(st)
+
+        action = _head_filter_action()
+        assert action != 'ignore', (
+            "importing hebo.sklearn_tuner installed a global "
+            "warnings 'ignore' filter, silencing all caller warnings"
+        )
+
+
+def test_tuning_does_not_leak_warning_filter():
+    # Running the tuner must leave the caller's warning filters unchanged.
+    import numpy as np
+    from sklearn.ensemble import RandomForestRegressor
+    from sklearn.metrics  import r2_score
+    from hebo.sklearn_tuner import sklearn_tuner
+
+    with warnings.catch_warnings():
+        warnings.resetwarnings()
+        warnings.simplefilter('default')
+        before = list(warnings.filters)
+
+        space_cfg = [
+            {'name' : 'max_depth', 'type' : 'int', 'lb' : 1, 'ub' : 4},
+        ]
+        X, y = np.random.randn(30, 2), np.random.randn(30)
+        sklearn_tuner(RandomForestRegressor, space_cfg, X, y,
+                      metric = r2_score, max_iter = 2, verbose = False)
+
+        after = list(warnings.filters)
+        assert after == before, (
+            "sklearn_tuner mutated the caller's global warnings.filters"
+        )


### PR DESCRIPTION
## Summary

`hebo/sklearn_tuner.py` calls `warnings.filterwarnings('ignore')` at **module import time**, which installs a process-wide `'ignore'` filter at the front of `warnings.filters`. Simply importing the module therefore silences warnings in the entire host program — including the caller's own warnings (related to #58).

## Fix

Remove the import-time global call and scope the suppression to the optimisation loop using `warnings.catch_warnings()`, which restores the caller's filter state on exit:

```python
with warnings.catch_warnings():
    warnings.simplefilter('ignore')
    ...  # tuning loop
```

## Tests

Adds `test/test_sklearn_tuner_warnings.py` — two regression tests: (1) importing the module installs no global `'ignore'` filter; (2) running the tuner does not leak filters into the caller. Both fail before the fix, pass after.

```
2 passed
```

Relates to #58.
